### PR TITLE
fix proposed block address when wrong one provided for writeAuthenticationKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -490,7 +490,6 @@ class MFRC522 {
 
     if (address % 4 !== 3) {
       const offset = 3 - (address % 4);
-      address = address + offset;
       console.log(
         "Error: Chosen block is not a sector trailer! " +
           "Please write authentication key to block " +


### PR DESCRIPTION
removed a debugging leftover, which fixes the address proposal in case of a wrong block number