### PR TITLE
 Applied fixes for electron v10.1.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,9 @@ class MFRC522 {
     this.reset_pin = pin;
     // Hold RESET pin low for 50ms to hard reset the reader
     rpio.open(this.reset_pin, rpio.OUTPUT, rpio.LOW);
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
-    rpio.write(this.reset_pin, rpio.HIGH);
+    setTimeout(function() {
+          rpio.write(this.reset_pin, rpio.HIGH);
+    }.bind(this), 50);
     return this;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mfrc522-rpi",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mfrc522-rpi",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "small JavaScript interface to control RFID reader MFRC522 with Raspberry-pi",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Applied the suggested fix by @firsttris in the issue #20 and tested the code on a "Raspberry Pi 4 Model B" with an MFRC522 rfid module. Works fine.

Changed the version number to 2.1.4 in the package.json and the package-lock.json files (Please check if I updated the version number correctly).